### PR TITLE
SWIFT-494 Introduce Dataset loading API

### DIFF
--- a/Sources/TFMongoSwift/Dataset.swift
+++ b/Sources/TFMongoSwift/Dataset.swift
@@ -57,7 +57,7 @@ public struct MongoDataset<M: TensorGroupMapping & Codable, T>: Sequence where M
     }
 
     /**
-     * Initialize a `Dataset` from the given MongoDB collection, optionally providing a filter, projection, or limit
+     * Initialize a `MongoDataset` from the given MongoDB collection, optionally providing a filter, projection, or limit
      * on the number of results.
      *
      * - Parameters:

--- a/Sources/TFMongoSwift/Dataset.swift
+++ b/Sources/TFMongoSwift/Dataset.swift
@@ -1,0 +1,103 @@
+import MongoSwift
+import TensorFlow
+
+public enum TFMongoSwiftError: Error {
+    case dataCorrupt
+}
+
+/// Dataset backed by a lazily evaluated cursor. Each batch makes a round trip to the server. Each iteration of the
+/// iterator yields a `TensorGroup` converted from the generic type associated with this Dataset.
+public struct MongoDataset<T: TensorGroupConvertible & Codable>: Sequence where T.TensorType: Combinable {
+    public typealias Iterator = MongoDatasetIterator<T>
+    public typealias Element = T.TensorType
+
+    private let client: MongoClient
+    private let db: String
+    private let collection: String
+    private var batchSize: Int32
+
+    public init(uri: String? = nil,
+                db: String,
+                collection: String,
+                mapping type: T.Type,
+                batchSize: Int32 = 32) throws {
+        if let uri = uri {
+            self.client = try MongoClient(uri)
+        } else {
+            self.client = try MongoClient()
+        }
+        self.db = db
+        self.collection = collection
+        self.batchSize = batchSize
+    }
+
+    public func batched(_ batchSize: Int32) throws -> MongoDataset<T> {
+        return try MongoDataset(db: self.db, collection: self.collection, mapping: T.self, batchSize: batchSize)
+    }
+
+    public func makeIterator() -> Iterator {
+        let coll = client.db(self.db).collection(self.collection, withType: T.self)
+        guard let cursor = try? coll.find(options: FindOptions(batchSize: self.batchSize)) else {
+            fatalError("error creating cursor")
+        }
+        return MongoDatasetIterator(wrapping: cursor, batchSize: self.batchSize)
+    }
+}
+
+/// Iterator for a `MongoDataset` backed by a lazily evaluated cursor. Each iteration makes constitutes a round trip to
+/// the server. The values are converted to their `TensorGroup` representation and combined into a single group.
+public struct MongoDatasetIterator<T: TensorGroupConvertible & Codable>: IteratorProtocol
+        where T.TensorType: Combinable {
+    private let cursor: MongoCursor<T>
+    private let batchSize: Int32
+
+    internal init(wrapping cursor: MongoCursor<T>, batchSize: Int32) {
+        self.cursor = cursor
+        self.batchSize = batchSize
+    }
+
+    public mutating func next() -> T.TensorType? {
+        var tensor: T.TensorType?
+        for _ in 0 ..< self.batchSize {
+            guard let record = self.cursor.next() else {
+                break
+            }
+            tensor = tensor?.combined(with: record.tensorValue) ?? record.tensorValue
+        }
+        return tensor
+    }
+}
+
+extension Dataset {
+    public init<T: TensorGroupConvertible & Codable>(from collection: MongoCollection<T>) throws
+            where T.TensorType == Element, Element: Combinable {
+        let cursor = try collection.find()
+        let tensors = cursor.reduce(nil) { (cumul: T.TensorType?, sample: T) in
+            cumul?.combined(with: sample.tensorValue) ?? sample.tensorValue
+        }
+
+        guard let t = tensors else {
+            throw TFMongoSwiftError.dataCorrupt
+        }
+
+        self.init(elements: t)
+    }
+
+    /// Gets a TensorFlow `Dataset` by converting values read from the given namespace to a `TensorGroup` as per
+    /// the generic `TensorGroupConvertible` type.
+    public init<T: TensorGroupConvertible & Codable>(uri: String? = nil,
+                                                     db: String,
+                                                     collection: String,
+                                                     mapping: T.Type) throws
+            where T.TensorType == Element, Element: Combinable {
+        let client: MongoClient
+        if let uri = uri {
+            client = try MongoClient(uri)
+        } else {
+            client = try MongoClient()
+        }
+        let coll = client.db(db).collection(collection, withType: T.self)
+
+        try self.init(from: coll)
+    }
+}

--- a/Sources/TFMongoSwift/Dataset.swift
+++ b/Sources/TFMongoSwift/Dataset.swift
@@ -1,10 +1,6 @@
 import MongoSwift
 import TensorFlow
 
-public enum TFMongoSwiftError: Error {
-    case dataCorrupt
-}
-
 private enum Query {
     case find(filter: Document?, opts: FindOptions)
     case aggregate(pipeline: [Document], opts: AggregateOptions)

--- a/Sources/TFMongoSwift/Dataset.swift
+++ b/Sources/TFMongoSwift/Dataset.swift
@@ -5,99 +5,222 @@ public enum TFMongoSwiftError: Error {
     case dataCorrupt
 }
 
+private enum Query {
+    case find(filter: Document?, opts: FindOptions)
+    case aggregate(pipeline: [Document], opts: AggregateOptions)
+
+    fileprivate var batchSize: Int32 {
+        switch self {
+        case let .find(_, opts):
+            // this value is always set
+            // swiftlint:disable:next force_unwrapping
+            return opts.batchSize!
+        case let .aggregate(_, opts):
+            // this value is always set
+            // swiftlint:disable:next force_unwrapping
+            return opts.batchSize!
+        }
+    }
+
+    fileprivate func execute(on collection: MongoCollection<Document>) throws -> MongoCursor<Document> {
+        switch self {
+        case let .find(filter, opts):
+            if let filter = filter {
+                return try collection.find(filter, options: opts)
+            }
+            return try collection.find(options: opts)
+        case let .aggregate(pipeline, opts):
+            return try collection.aggregate(pipeline, options: opts)
+        }
+    }
+}
+
 /// Dataset backed by a lazily evaluated cursor. Each batch makes a round trip to the server. Each iteration of the
-/// iterator yields a `TensorGroup` converted from the generic type associated with this Dataset.
-public struct MongoDataset<T: TensorGroupConvertible & Codable>: Sequence where T.TensorType: Combinable {
-    public typealias Iterator = MongoDatasetIterator<T>
-    public typealias Element = T.TensorType
+/// iterator yields a `TensorGroup` converted from the first generic type to the second.
+public struct MongoDataset<C: Codable, T: TensorGroup & InitializableFromSequence>: Sequence where T.SequenceType == C {
+    public typealias Iterator = MongoDatasetIterator<C, T>
+    public typealias Element = T
 
     private let client: MongoClient
-    private let db: String
-    private let collection: String
-    private var batchSize: Int32
+    private let collection: MongoCollection<Document>
+    private var query: Query
 
-    public init(uri: String? = nil,
-                db: String,
-                collection: String,
-                mapping type: T.Type,
-                batchSize: Int32 = 32) throws {
+    private var batchSize: Int32 {
+        get {
+            return self.query.batchSize
+        }
+        set(newSize) {
+            switch self.query {
+            case let .find(filter, opts):
+                let newOpts = FindOptions(batchSize: newSize, limit: opts.limit, projection: opts.projection)
+                self.query = .find(filter: filter, opts: newOpts)
+            case let .aggregate(pipeline, _):
+                let newOpts = AggregateOptions(batchSize: newSize)
+                self.query = .aggregate(pipeline: pipeline, opts: newOpts)
+            }
+        }
+    }
+
+    /// Initialize a `Dataset` from the result of the provided MongoDB aggregation pipeline.
+    /// - SeeAlso: https://docs.mongodb.com/manual/aggregation/
+    public init(uri: String? = nil, db: String, collection: String, pipeline: [Document]) throws {
         if let uri = uri {
             self.client = try MongoClient(uri)
         } else {
             self.client = try MongoClient()
         }
-        self.db = db
-        self.collection = collection
-        self.batchSize = batchSize
+        self.collection = client.db(db).collection(collection)
+        self.query = .aggregate(pipeline: pipeline, opts: AggregateOptions(batchSize: 1))
     }
 
-    public func batched(_ batchSize: Int32) throws -> MongoDataset<T> {
-        return try MongoDataset(db: self.db, collection: self.collection, mapping: T.self, batchSize: batchSize)
+    /// Initialize a `Dataset` from the given MongoDB collection, optionally providing a filter, projection, or limit
+    /// on the number of results.
+    public init(uri: String? = nil,
+                db: String,
+                collection: String,
+                filter: Document? = nil,
+                projection: Document? = nil,
+                limit: Int64? = nil) throws {
+        if let uri = uri {
+            self.client = try MongoClient(uri)
+        } else {
+            self.client = try MongoClient()
+        }
+
+        self.collection = self.client.db(db).collection(collection)
+        let opts = FindOptions(batchSize: 1, limit: limit, projection: projection)
+        self.query = .find(filter: filter, opts: opts)
+    }
+
+    private init(copying dataset: MongoDataset<C, T>) {
+        self.client = dataset.client
+        self.collection = dataset.collection
+        self.query = dataset.query
+    }
+
+    /// Returns a copy of this dataset that populates the `TensorGroup`s yielded by iteration with batches of tensors
+    /// from the given dataset.
+    public func batched(_ batchSize: Int32) throws -> MongoDataset<C, T> {
+        var other = MongoDataset(copying: self)
+        other.batchSize = batchSize
+        return other
     }
 
     public func makeIterator() -> Iterator {
-        let coll = client.db(self.db).collection(self.collection, withType: T.self)
-        guard let cursor = try? coll.find(options: FindOptions(batchSize: self.batchSize)) else {
-            fatalError("error creating cursor")
+        guard let cursor = try? self.query.execute(on: self.collection) else {
+            fatalError("couldn't get cursor")
         }
-        return MongoDatasetIterator(wrapping: cursor, batchSize: self.batchSize)
+        return Iterator(wrapping: cursor, batchSize: self.batchSize)
     }
 }
 
 /// Iterator for a `MongoDataset` backed by a lazily evaluated cursor. Each iteration makes constitutes a round trip to
 /// the server. The values are converted to their `TensorGroup` representation and combined into a single group.
-public struct MongoDatasetIterator<T: TensorGroupConvertible & Codable>: IteratorProtocol
-        where T.TensorType: Combinable {
-    private let cursor: MongoCursor<T>
+public struct MongoDatasetIterator<C: Codable, T: TensorGroup & InitializableFromSequence>: IteratorProtocol
+        where T.SequenceType == C {
+    private let cursor: MongoCursor<Document>
     private let batchSize: Int32
 
-    internal init(wrapping cursor: MongoCursor<T>, batchSize: Int32) {
+    internal init(wrapping cursor: MongoCursor<Document>, batchSize: Int32) {
         self.cursor = cursor
         self.batchSize = batchSize
     }
 
-    public mutating func next() -> T.TensorType? {
-        var tensor: T.TensorType?
+    public mutating func next() -> T? {
+        let decoder = BSONDecoder()
+        var elements: [C] = []
         for _ in 0 ..< self.batchSize {
             guard let record = self.cursor.next() else {
+                if let error = self.cursor.error {
+                    if case UserError.logicError(_) = error {
+                        continue
+                    } else {
+                        print("failed iterating cursor: \(error)")
+                    }
+                }
                 break
             }
-            tensor = tensor?.combined(with: record.tensorValue) ?? record.tensorValue
+            guard let element = try? decoder.decode(C.self, from: record) else {
+                print("failed decoding from \(record)")
+                break
+            }
+            elements.append(element)
         }
-        return tensor
+
+        guard !elements.isEmpty else {
+            return nil
+        }
+
+        return T(from: elements)
     }
 }
 
 extension Dataset {
-    public init<T: TensorGroupConvertible & Codable>(from collection: MongoCollection<T>) throws
-            where T.TensorType == Element, Element: Combinable {
-        let cursor = try collection.find()
-        let tensors = cursor.reduce(nil) { (cumul: T.TensorType?, sample: T) in
-            cumul?.combined(with: sample.tensorValue) ?? sample.tensorValue
+    /// Initialize a `Dataset` from the result of a MongoDB query.
+    /// An optional "transform" function can also be passed in that mutates the entire dataset before it is batched
+    /// (e.g. for normalization).
+    public init<T: Codable>(from cursor: MongoCursor<T>, transform: ((inout Element) -> Void)? = nil)
+            where Element: InitializableFromSequence, Element.SequenceType == T {
+        var elements = Element(from: Array(cursor))
+
+        if let f = transform {
+            f(&elements)
         }
 
-        guard let t = tensors else {
-            throw TFMongoSwiftError.dataCorrupt
-        }
-
-        self.init(elements: t)
+        self.init(elements: elements)
     }
 
-    /// Gets a TensorFlow `Dataset` by converting values read from the given namespace to a `TensorGroup` as per
-    /// the generic `TensorGroupConvertible` type.
-    public init<T: TensorGroupConvertible & Codable>(uri: String? = nil,
-                                                     db: String,
-                                                     collection: String,
-                                                     mapping: T.Type) throws
-            where T.TensorType == Element, Element: Combinable {
+    /// Initialize a `Dataset` from the result of the provided MongoDB aggregation pipeline.
+    /// An optional "transform" function can also be passed in that mutates the entire dataset before it is batched
+    /// (e.g. for normalization).
+    /// - SeeAlso: https://docs.mongodb.com/manual/aggregation/
+    public init<C: Codable>(uri: String? = nil,
+                            db: String,
+                            collection: String,
+                            pipeline: [Document],
+                            outputType: C.Type,
+                            transform: ((inout Element) -> Void)? = nil) throws
+            where Element: InitializableFromSequence, Element.SequenceType == C {
         let client: MongoClient
         if let uri = uri {
             client = try MongoClient(uri)
         } else {
             client = try MongoClient()
         }
-        let coll = client.db(db).collection(collection, withType: T.self)
+        let coll = client.db(db).collection(collection)
+        let cursor = try coll.aggregate(pipeline)
 
-        try self.init(from: coll)
+        let decoder = BSONDecoder()
+        var elements = Element(from: try cursor.map { try decoder.decode(C.self, from: $0) })
+
+        if let f = transform {
+            f(&elements)
+        }
+
+        self.init(elements: elements)
+    }
+
+    /// Initialize a `Dataset` from the given MongoDB collection, optionally providing a filter, projection, or limit
+    /// on the number of results.
+    /// An optional "transform" function can also be passed in that mutates the entire dataset before it is batched
+    /// (e.g. for normalization).
+    public init<C: Codable>(uri: String? = nil,
+                            db: String,
+                            collection: String,
+                            filter: Document = [:],
+                            projection: Document? = nil,
+                            limit: Int64? = nil,
+                            collectionType: C.Type,
+                            transform: ((inout Element) -> Void)? = nil) throws
+            where Element: InitializableFromSequence, Element.SequenceType == C {
+        let client: MongoClient
+        if let uri = uri {
+            client = try MongoClient(uri)
+        } else {
+            client = try MongoClient()
+        }
+        let coll = client.db(db).collection(collection, withType: C.self)
+        let cursor = try coll.find(filter, options: FindOptions(limit: limit, projection: projection))
+        self.init(from: cursor, transform: transform)
     }
 }

--- a/Sources/TFMongoSwift/Dataset.swift
+++ b/Sources/TFMongoSwift/Dataset.swift
@@ -30,8 +30,17 @@ public struct MongoDataset<M: TensorGroupMapping & Codable, T>: Sequence where M
     private let groupFactory: () -> T
     private var batchSize: Int = 1
 
-    /// Initialize a `Dataset` from the result of the provided MongoDB aggregation pipeline.
-    /// - SeeAlso: https://docs.mongodb.com/manual/aggregation/
+    /**
+     * Initialize a `MongoDataset` from the result of the provided MongoDB aggregation pipeline.
+     *
+     * - Parameters:
+     *   - uri: Optional, the MongoDB connection string designating which MongoDB instance to connect to. Defaults
+     *          to localhost:27017.
+     *   - db: The name of the database to perform the aggregation against.
+     *   - collection: The name of the collection to perform the aggregation against.
+     *   - groupFactory: A closure that can produce an empty instance of the `TensorGroup` to be populated.
+     * - SeeAlso: https://docs.mongodb.com/manual/aggregation/
+     */
     public init(uri: String? = nil,
                 db: String,
                 collection: String,
@@ -47,8 +56,20 @@ public struct MongoDataset<M: TensorGroupMapping & Codable, T>: Sequence where M
         self.groupFactory = groupFactory
     }
 
-    /// Initialize a `Dataset` from the given MongoDB collection, optionally providing a filter, projection, or limit
-    /// on the number of results.
+    /**
+     * Initialize a `Dataset` from the given MongoDB collection, optionally providing a filter, projection, or limit
+     * on the number of results.
+     *
+     * - Parameters:
+     *   - uri: Optional, the MongoDB connection string designating which MongoDB instance to connect to. Defaults
+     *          to localhost:27017.
+     *   - db: The name of the database to containing the dataset collection.
+     *   - collection: The name of the collection containing the dataset.
+     *   - filter: Optional, a filter that documents must match to be included in the dataset.
+     *   - projection: Optional, a document specifying which fields should be included in the retrieved documents.
+     *   - limit: Optional, a limit on the number of documents included in the dataset.
+     *   - groupFactory: A closure that can produce an empty instance of the `TensorGroup` to be populated.
+     */
     public init(uri: String? = nil,
                 db: String,
                 collection: String,

--- a/Sources/TFMongoSwift/TFMongoSwiftError.swift
+++ b/Sources/TFMongoSwift/TFMongoSwiftError.swift
@@ -1,0 +1,8 @@
+public enum TFMongoSwiftError: Error {
+    /// The mappings provided as part of a `TensorGroupMapping` did not all have the same shape/format.
+    case nonUniformMappings
+
+    /// No scalars were found for a particular `Tensor` on a `TensorGroup` being mapped to with the default
+    /// `TensorGroupMapping` conformance.
+    case noMatchingScalars(message: String)
+}

--- a/Sources/TFMongoSwift/TensorGroup.swift
+++ b/Sources/TFMongoSwift/TensorGroup.swift
@@ -5,48 +5,319 @@ import TensorFlow
 /// This file defines protocols and structures that help facilitate mapping between data stored in MongoDB and
 /// `TensorGroup`s.
 
-/// A basic `TensorGroup` that consisting of a `Tensor` of features and a `Tensor` of labels.
-public struct FLB<T: FeatureLabelMapping>: TensorGroup, InitializableFromSequence {
-    public typealias SequenceType = T
+/// Enum specifying the possible maps from a path on a `TensorGroup` to a `Tensor`.
+public enum TensorMap<G: TensorGroup> {
+    /// A mapping of a `KeyPath` to a `Tensor<Bool>` to a `Tensor<Bool>`.
+    case bool(WritableKeyPath<G, Tensor<Bool>>, Tensor<Bool>)
 
-    /// The features for this batch of data.
-    public var features: Tensor<T.FeatureType>
+    /// A mapping of a `KeyPath` to a `Tensor<Int8>` to a `Tensor<Int8>`.
+    case int8(WritableKeyPath<G, Tensor<Int8>>, Tensor<Int8>)
 
-    /// The labels for this batch of data.
-    public var labels: Tensor<T.LabelType>
+    /// A mapping of a `KeyPath` to a `Tensor<Int16>` to a `Tensor<Int16>`.
+    case int16(WritableKeyPath<G, Tensor<Int16>>, Tensor<Int16>)
 
-    public init<S: Sequence>(from elements: S) where S.Element == SequenceType {
-        var featureScalars: [T.FeatureType] = []
-        var labelScalars: [T.LabelType] = []
+    /// A mapping of a `KeyPath` to a `Tensor<Int32>` to a `Tensor<Int32>`.
+    case int32(WritableKeyPath<G, Tensor<Int32>>, Tensor<Int32>)
 
-        for element in elements {
-            featureScalars += element.features
-            labelScalars.append(element.label)
+    /// A mapping of a `KeyPath` to a `Tensor<Int64>` to a `Tensor<Int64>`.
+    case int64(WritableKeyPath<G, Tensor<Int64>>, Tensor<Int64>)
+
+    /// A mapping of a `KeyPath` to a `Tensor<Double>` to a `Tensor<Double>`.
+    case double(WritableKeyPath<G, Tensor<Double>>, Tensor<Double>)
+
+    /// A mapping of a `KeyPath` to a `Tensor<Float>` to a `Tensor<Float>`.
+    case float(WritableKeyPath<G, Tensor<Float>>, Tensor<Float>)
+
+    /// A mapping of a `KeyPath` to a `Tensor<UInt8>` to a `Tensor<UInt8>`.
+    case uint8(WritableKeyPath<G, Tensor<UInt8>>, Tensor<UInt8>)
+
+    /// A mapping of a `KeyPath` to a `Tensor<UInt16>` to a `Tensor<UInt16>`.
+    case uint16(WritableKeyPath<G, Tensor<UInt16>>, Tensor<UInt16>)
+
+    /// A mapping of a `KeyPath` to a `Tensor<UInt32>` to a `Tensor<UInt32>`.
+    case uint32(WritableKeyPath<G, Tensor<UInt32>>, Tensor<UInt32>)
+
+    /// A mapping of a `KeyPath` to a `Tensor<UInt64>` to a `Tensor<UInt64>`.
+    case uint64(WritableKeyPath<G, Tensor<UInt64>>, Tensor<UInt64>)
+
+    // Gets the `Tensor` from this map if the path matches.
+    // swiftlint:disable:next cyclomatic_complexity
+    fileprivate func extractTensor<T: TensorFlowScalar>(at path: WritableKeyPath<G, Tensor<T>>) -> Tensor<T>? {
+        switch T.self {
+        case is Bool.Type:
+            guard case let .bool(mapPath, tensor) = self, path == mapPath else {
+                return nil
+            }
+            return tensor as? Tensor<T>
+        case is Int8.Type:
+            guard case let .int8(mapPath, tensor) = self, path == mapPath else {
+                return nil
+            }
+            return tensor as? Tensor<T>
+        case is Int16.Type:
+            guard case let .int16(mapPath, tensor) = self, path == mapPath else {
+                return nil
+            }
+            return tensor as? Tensor<T>
+        case is Int32.Type:
+            guard case let .int32(mapPath, tensor) = self, path == mapPath else {
+                return nil
+            }
+            return tensor as? Tensor<T>
+        case is Int64.Type:
+            guard case let .int64(mapPath, tensor) = self, path == mapPath else {
+                return nil
+            }
+            return tensor as? Tensor<T>
+        case is Double.Type:
+            guard case let .double(mapPath, tensor) = self, path == mapPath else {
+                return nil
+            }
+            return tensor as? Tensor<T>
+        case is Float.Type:
+            guard case let .float(mapPath, tensor) = self, path == mapPath else {
+                return nil
+            }
+            return tensor as? Tensor<T>
+        case is UInt8.Type:
+            guard case let .uint8(mapPath, tensor) = self, path == mapPath else {
+                return nil
+            }
+            return tensor as? Tensor<T>
+        case is UInt16.Type:
+            guard case let .uint16(mapPath, tensor) = self, path == mapPath else {
+                return nil
+            }
+            return tensor as? Tensor<T>
+        case is UInt32.Type:
+            guard case let .uint32(mapPath, tensor) = self, path == mapPath else {
+                return nil
+            }
+            return tensor as? Tensor<T>
+        case is UInt64.Type:
+            guard case let .uint64(mapPath, tensor) = self, path == mapPath else {
+                return nil
+            }
+            return tensor as? Tensor<T>
+        default:
+            return nil
         }
-
-        var shape = T.featureShape
-        shape[0] = labelScalars.count
-        self.features = Tensor(shape: shape, scalars: featureScalars)
-        self.labels = Tensor(labelScalars)
     }
 }
 
-/// Allows defining a direct mapping to a `FeatureLabelBatch`.
-public protocol FeatureLabelMapping: Codable {
-    associatedtype FeatureType: TensorFlowScalar
-    associatedtype LabelType: TensorFlowScalar
+/// Defines a custom mapping of this object to an associated `TensorGroup`.
+/// The default conformance of this protocol will map all the properties that conform to `TensorFlowScalar` to the first
+/// `Tensor` of that type found on the associated `TensorGroup`.
+public protocol TensorGroupMapping: KeyPathIterable {
+    /// The `TensorGroup` this maps to.
+    associatedtype Group: KeyPathIterable, TensorGroup
 
-    static var featureShape: TensorShape { get }
-    var features: [FeatureType] { get }
-    var label: LabelType { get }
+    /// The mapping from the output `TensorGroup`'s properties to custom values.
+    var mapping: [TensorMap<Self.Group>]? { get }
 }
 
-/// Allows initializing a type from a sequence of another type. Required for mapping a collection's data to a
-/// `TensorGroup`.
-public protocol InitializableFromSequence {
-    /// Can be initialized from a sequence of this type.
-    associatedtype SequenceType
+extension TensorGroupMapping {
+    /// The default mapping (nil). This means that all properties that conform to `TensorFlowScalar` will be mapped to
+    /// the first `Tensor` of that type found on the associated `TensorGroup`.
+    public var mapping: [TensorMap<Self.Group>]? { return nil }
+}
 
-    /// Initialize from a sequence of the associated `SequenceType`.
-    init<S: Sequence>(from sequence: S) where S.Element == SequenceType
+extension TensorGroup where Self: KeyPathIterable {
+    /// Concatenate the provided scalars to the `Tensor` found at the path. If overwrite is specified, it will replace
+    /// the existing tensor with a new one constructed from the scalars.
+    private mutating func concatenateTensors<T: TensorFlowScalar>(at path: WritableKeyPath<Self, Tensor<T>>,
+                                                                  tensor: Tensor<T>,
+                                                                  overwrite: Bool) throws {
+        guard overwrite || tensor.shape.dimensions[0...] == self[keyPath: path].shape.dimensions[1...] else {
+            throw TFMongoSwiftError.nonUniformMappings
+        }
+
+        let newTensor = tensor.reshaped(to: TensorShape([1] + tensor.shape.dimensions))
+
+        if overwrite {
+            self[keyPath: path] = newTensor
+        } else {
+            self[keyPath: path] = self[keyPath: path].concatenated(with: newTensor)
+        }
+    }
+
+    /// Map all the scalars of type `T` from the array of `KeyPathIterable`s to the first writeable `Tensor<T>` field.
+    private mutating func mapAllScalarsToFirst<T: TensorFlowScalar, K: KeyPathIterable>(type: T.Type,
+                                                                                        elements: [K]) throws {
+        var scalars: [T] = []
+        if let path = self.allWritableKeyPaths(to: Tensor<T>.self).first {
+            scalars += elements.flatMap { s in s.allKeyPaths(to: T.self).map { s[keyPath: $0] } }
+            scalars += elements.flatMap { s in s.allKeyPaths(to: [T].self).flatMap { s[keyPath: $0] } }
+
+            guard !scalars.isEmpty else {
+                throw TFMongoSwiftError.noMatchingScalars(message: "Could not find any scalars of type \(T.self) to " +
+                        "map.")
+            }
+
+            self[keyPath: path] = Tensor<T>(shape: [elements.count, scalars.count / elements.count], scalars: scalars)
+        }
+    }
+
+    // swiftlint:disable force_unwrapping
+    /// Overwrites the `Tensor` at the given path by extracting the `Tensor` from each of the maps and combining all the
+    /// scalars. All of the maps MUST share the same path component.
+    private mutating func assignTensor<S: TensorFlowScalar>(at path: WritableKeyPath<Self, Tensor<S>>,
+                                                            maps: [TensorMap<Self>]) {
+        guard !maps.isEmpty else {
+            return
+        }
+        // The extraction is guaranteed to succeed due to the path precondition of invoking this method.
+        let scalars = maps.flatMap { $0.extractTensor(at: path)!.scalars }
+        // Maps is guaranteed to be non-empty, the extraction should also succeed here for the same reason as the
+        // previous.
+        let shape = TensorShape([maps.count] + maps.first!.extractTensor(at: path)!.shape.dimensions)
+        self[keyPath: path] = Tensor<S>(shape: shape, scalars: scalars)
+    }
+    // swiftlint:enable force_unwrapping
+
+    // swiftlint:disable cyclomatic_complexity
+    /// Populate this `TensorGroup` from the provided array of `TensorGroupMapping`s.
+    public mutating func populate<M: TensorGroupMapping>(mappings: [M]) throws where M.Group == Self {
+        guard !mappings.isEmpty else {
+            return
+        }
+
+        guard let first = mappings.first?.mapping else {
+            // map each tensor to values of the same scalar type
+            try self.mapAllScalarsToFirst(type: Double.self, elements: mappings)
+            try self.mapAllScalarsToFirst(type: Float.self, elements: mappings)
+            try self.mapAllScalarsToFirst(type: Int8.self, elements: mappings)
+            try self.mapAllScalarsToFirst(type: Int16.self, elements: mappings)
+            try self.mapAllScalarsToFirst(type: Int32.self, elements: mappings)
+            try self.mapAllScalarsToFirst(type: Int64.self, elements: mappings)
+            try self.mapAllScalarsToFirst(type: UInt8.self, elements: mappings)
+            try self.mapAllScalarsToFirst(type: UInt16.self, elements: mappings)
+            try self.mapAllScalarsToFirst(type: UInt32.self, elements: mappings)
+            try self.mapAllScalarsToFirst(type: UInt64.self, elements: mappings)
+            try self.mapAllScalarsToFirst(type: Bool.self, elements: mappings)
+            return
+        }
+
+        for (i, map) in first.enumerated() {
+            let allMaps: [TensorMap<Self>] = try mappings.compactMap {
+                guard let mapping = $0.mapping, mapping.count > i else {
+                    throw TFMongoSwiftError.nonUniformMappings
+                }
+                return mapping[i]
+            }
+
+            switch map {
+            case let .bool(path, _):
+                self.assignTensor(at: path, maps: allMaps)
+            case let .int8(path, _):
+                self.assignTensor(at: path, maps: allMaps)
+            case let .int16(path, _):
+                self.assignTensor(at: path, maps: allMaps)
+            case let .int32(path, _):
+                self.assignTensor(at: path, maps: allMaps)
+            case let .int64(path, _):
+                self.assignTensor(at: path, maps: allMaps)
+            case let .double(path, _):
+                self.assignTensor(at: path, maps: allMaps)
+            case let .float(path, _):
+                self.assignTensor(at: path, maps: allMaps)
+            case let .uint8(path, _):
+                self.assignTensor(at: path, maps: allMaps)
+            case let .uint16(path, _):
+                self.assignTensor(at: path, maps: allMaps)
+            case let .uint32(path, _):
+                self.assignTensor(at: path, maps: allMaps)
+            case let .uint64(path, _):
+                self.assignTensor(at: path, maps: allMaps)
+            }
+        }
+    }
+    // swiftlint:enable cyclomatic_complexity
+
+    /// Returns a copy of this `TensorGroup` populated according to the given array of `TensorGroupMapping`s.
+    public func populated<M: TensorGroupMapping>(mappings: [M]) throws -> Self where M.Group == Self {
+        var copy = self
+        try copy.populate(mappings: mappings)
+        return copy
+    }
+
+    /// Returns a copy of this `TensorGroup` populated from the given MongoDB collection according to the provided
+    /// `TensorGroupMapping`.
+    public func populated<M: TensorGroupMapping & Codable>(uri: String? = nil,
+                                                           db: String,
+                                                           collection: String,
+                                                           filter: Document = [:],
+                                                           projection: Document? = nil,
+                                                           limit: Int64? = nil,
+                                                           mapping: M.Type) throws -> Self where M.Group == Self {
+        var copy = self
+        try copy.populate(uri: uri,
+                          db: db,
+                          collection: collection,
+                          filter: filter,
+                          projection: projection,
+                          limit: limit,
+                          mapping: M.self)
+        return copy
+    }
+
+    /// Populate this `TensorGroup` from the given MongoDB collection according to the provided `TensorGroupMapping`.
+    public mutating func populate<M: TensorGroupMapping & Codable>(uri: String? = nil,
+                                                                   db: String,
+                                                                   collection: String,
+                                                                   filter: Document = [:],
+                                                                   projection: Document? = nil,
+                                                                   limit: Int64? = nil,
+                                                                   mapping: M.Type) throws where M.Group == Self {
+        let client: MongoClient
+        if let uri = uri {
+            client = try MongoClient(uri)
+        } else {
+            client = try MongoClient()
+        }
+
+        let options = FindOptions(limit: limit, projection: projection)
+        let data = try Array(client.db(db).collection(collection, withType: M.self).find(filter, options: options))
+        try self.populate(mappings: data)
+    }
+
+    /// Returns a copy of this `TensorGroup` populated from the results of the given MongoDB aggregation query on the
+    /// given namespace according to the provided `TensorGroupMapping`.
+    /// `TensorGroupMapping`.
+    public func populated<M: TensorGroupMapping & Codable>(uri: String? = nil,
+                                                           db: String,
+                                                           collection: String,
+                                                           pipeline: [Document],
+                                                           mapping: M.Type) throws -> Self where M.Group == Self {
+        var copy = self
+        try copy.populate(uri: uri,
+                          db: db,
+                          collection: collection,
+                          pipeline: pipeline,
+                          mapping: M.self)
+        return copy
+    }
+
+    /// Populate this `TensorGroup` from the results of the given MongoDB aggregation query on the given namespace
+    /// according to the provided `TensorGroupMapping`.
+    /// - SeeAlso: https://docs.mongodb.com/manual/aggregation/
+    public mutating func populate<M: TensorGroupMapping & Codable>(uri: String? = nil,
+                                                                   db: String,
+                                                                   collection: String,
+                                                                   pipeline: [Document],
+                                                                   mapping: M.Type) throws where M.Group == Self {
+        let client: MongoClient
+        if let uri = uri {
+            client = try MongoClient(uri)
+        } else {
+            client = try MongoClient()
+        }
+
+        let data = try client
+                .db(db)
+                .collection(collection)
+                .aggregate(pipeline)
+                .map { try BSONDecoder().decode(M.self, from: $0) }
+        try self.populate(mappings: data)
+    }
 }

--- a/Sources/TFMongoSwift/TensorGroup.swift
+++ b/Sources/TFMongoSwift/TensorGroup.swift
@@ -2,51 +2,51 @@ import Foundation
 import MongoSwift
 import TensorFlow
 
-/// This file defines protocols that help facilitate mapping between data stored in MongoDB and `TensorGroup`s.
+/// This file defines protocols and structures that help facilitate mapping between data stored in MongoDB and
+/// `TensorGroup`s.
 
-/// Allows a given `TensorGroup` to be combined (e.g. adding rows) with another `TensorGroup` of the same type.
-public protocol Combinable where Self: TensorGroup {
-    /// Returns a new `TensorGroup` of the same type as `self` which is the result of combining `self` with the supplied
-    /// `TensorGroup`.
-    func combined(with other: Self) -> Self
-}
+/// A basic `TensorGroup` that consisting of a `Tensor` of features and a `Tensor` of labels.
+public struct FLB<T: FeatureLabelMapping>: TensorGroup, InitializableFromSequence {
+    public typealias SequenceType = T
 
-/// A type conforming to `TensorGroup` and `Combinable` that contains two tensors: one for features and one for labels.
-/// Can be used as a generic batch type on a Dataset for a wide variety of applications.
-public struct FeatureLabelBatch<FeatureType: TensorFlowScalar, LabelType: TensorFlowScalar>: TensorGroup, Combinable {
-    public let features: Tensor<FeatureType>
-    public let labels: Tensor<LabelType>
+    /// The features for this batch of data.
+    public var features: Tensor<T.FeatureType>
 
-    public func combined(with other: FeatureLabelBatch<FeatureType, LabelType>)
-                    -> FeatureLabelBatch<FeatureType, LabelType> {
-        return FeatureLabelBatch(features: self.features.concatenated(with: other.features),
-                                 labels: self.labels.concatenated(with: other.labels))
+    /// The labels for this batch of data.
+    public var labels: Tensor<T.LabelType>
+
+    public init<S: Sequence>(from elements: S) where S.Element == SequenceType {
+        var featureScalars: [T.FeatureType] = []
+        var labelScalars: [T.LabelType] = []
+
+        for element in elements {
+            featureScalars += element.features
+            labelScalars.append(element.label)
+        }
+
+        var shape = T.featureShape
+        shape[0] = labelScalars.count
+        self.features = Tensor(shape: shape, scalars: featureScalars)
+        self.labels = Tensor(labelScalars)
     }
 }
 
-/// Allows a type to be converted to a given `TensorGroup`.
-public protocol TensorGroupConvertible {
-    associatedtype TensorType: TensorGroup
-
-    var tensorValue: TensorType { get }
-}
-
 /// Allows defining a direct mapping to a `FeatureLabelBatch`.
-public protocol FeatureLabelMapping: TensorGroupConvertible, Codable
-        where Self.TensorType == FeatureLabelBatch<FeatureType, LabelType> {
+public protocol FeatureLabelMapping: Codable {
     associatedtype FeatureType: TensorFlowScalar
     associatedtype LabelType: TensorFlowScalar
 
-    static var NUM_FEATURES: Int { get }
+    static var featureShape: TensorShape { get }
     var features: [FeatureType] { get }
     var label: LabelType { get }
 }
 
-extension FeatureLabelMapping {
-    public var tensorValue: TensorType {
-        let features = self.features
-        let featuresTensor = Tensor<FeatureType>(shape: [1, features.count], scalars: features)
-        let labels = Tensor<LabelType>([self.label])
-        return FeatureLabelBatch(features: featuresTensor, labels: labels)
-    }
+/// Allows initializing a type from a sequence of another type. Required for mapping a collection's data to a
+/// `TensorGroup`.
+public protocol InitializableFromSequence {
+    /// Can be initialized from a sequence of this type.
+    associatedtype SequenceType
+
+    /// Initialize from a sequence of the associated `SequenceType`.
+    init<S: Sequence>(from sequence: S) where S.Element == SequenceType
 }

--- a/Sources/TFMongoSwift/TensorGroup.swift
+++ b/Sources/TFMongoSwift/TensorGroup.swift
@@ -241,8 +241,20 @@ extension TensorGroup where Self: KeyPathIterable {
         return copy
     }
 
-    /// Returns a copy of this `TensorGroup` populated from the given MongoDB collection according to the provided
-    /// `TensorGroupMapping`.
+    /**
+     * Returns a copy of this `TensorGroup` populated from the given MongoDB collection according to the provided
+     * `TensorGroupMapping`.
+     *
+     * - Parameters:
+     *   - uri: Optional, the MongoDB connection string designating which MongoDB instance to connect to. Defaults
+     *          to localhost:27017.
+     *   - db: The name of the database to containing the dataset collection.
+     *   - collection: The name of the collection containing the dataset.
+     *   - filter: Optional, a filter that documents must match to be included in the dataset.
+     *   - projection: Optional, a document specifying which fields should be included in the retrieved documents.
+     *   - limit: Optional, a limit on the number of documents included in the dataset.
+     *   - mapping: The `TensorGroupMapping` used to map fields of the documents to the output `TensorGroup`.
+     */
     public func populated<M: TensorGroupMapping & Codable>(uri: String? = nil,
                                                            db: String,
                                                            collection: String,
@@ -261,7 +273,19 @@ extension TensorGroup where Self: KeyPathIterable {
         return copy
     }
 
-    /// Populate this `TensorGroup` from the given MongoDB collection according to the provided `TensorGroupMapping`.
+    /**
+     * Populate this `TensorGroup` from the given MongoDB collection according to the provided `TensorGroupMapping`.
+     *
+     * - Parameters:
+     *   - uri: Optional, the MongoDB connection string designating which MongoDB instance to connect to. Defaults
+     *          to localhost:27017.
+     *   - db: The name of the database to containing the dataset collection.
+     *   - collection: The name of the collection containing the dataset.
+     *   - filter: Optional, a filter that documents must match to be included in the dataset.
+     *   - projection: Optional, a document specifying which fields should be included in the retrieved documents.
+     *   - limit: Optional, a limit on the number of documents included in the dataset.
+     *   - mapping: The `TensorGroupMapping` used to map fields of the documents to this `TensorGroup`.
+     */
     public mutating func populate<M: TensorGroupMapping & Codable>(uri: String? = nil,
                                                                    db: String,
                                                                    collection: String,
@@ -281,9 +305,18 @@ extension TensorGroup where Self: KeyPathIterable {
         try self.populate(mappings: data)
     }
 
-    /// Returns a copy of this `TensorGroup` populated from the results of the given MongoDB aggregation query on the
-    /// given namespace according to the provided `TensorGroupMapping`.
-    /// `TensorGroupMapping`.
+    /**
+     * Returns a copy of this `TensorGroup` populated from the results of the given MongoDB aggregation query on the
+     * given namespace according to the provided `TensorGroupMapping`.
+     *
+     * - Parameters:
+     *   - uri: Optional, the MongoDB connection string designating which MongoDB instance to connect to. Defaults
+     *          to localhost:27017.
+     *   - db: The name of the database to perform the aggregation against.
+     *   - collection: The name of the collection to perform the aggregation against.
+     *   - mapping: The `TensorGroupMapping` used to map fields of the result documents to the output `TensorGroup`.
+     * - SeeAlso: https://docs.mongodb.com/manual/aggregation/
+     */
     public func populated<M: TensorGroupMapping & Codable>(uri: String? = nil,
                                                            db: String,
                                                            collection: String,
@@ -298,9 +331,18 @@ extension TensorGroup where Self: KeyPathIterable {
         return copy
     }
 
-    /// Populate this `TensorGroup` from the results of the given MongoDB aggregation query on the given namespace
-    /// according to the provided `TensorGroupMapping`.
-    /// - SeeAlso: https://docs.mongodb.com/manual/aggregation/
+    /**
+     * Populate this `TensorGroup` from the results of the given MongoDB aggregation query on the given namespace
+     *  according to the provided `TensorGroupMapping`.
+     *
+     * - Parameters:
+     *   - uri: Optional, the MongoDB connection string designating which MongoDB instance to connect to. Defaults
+     *          to localhost:27017.
+     *   - db: The name of the database to perform the aggregation against.
+     *   - collection: The name of the collection to perform the aggregation against.
+     *   - mapping: The `TensorGroupMapping` used to map fields of the result documents to this `TensorGroup`.
+     * - SeeAlso: https://docs.mongodb.com/manual/aggregation/
+     */
     public mutating func populate<M: TensorGroupMapping & Codable>(uri: String? = nil,
                                                                    db: String,
                                                                    collection: String,

--- a/Sources/TFMongoSwift/TensorGroup.swift
+++ b/Sources/TFMongoSwift/TensorGroup.swift
@@ -1,0 +1,52 @@
+import Foundation
+import MongoSwift
+import TensorFlow
+
+/// This file defines protocols that help facilitate mapping between data stored in MongoDB and `TensorGroup`s.
+
+/// Allows a given `TensorGroup` to be combined (e.g. adding rows) with another `TensorGroup` of the same type.
+public protocol Combinable where Self: TensorGroup {
+    /// Returns a new `TensorGroup` of the same type as `self` which is the result of combining `self` with the supplied
+    /// `TensorGroup`.
+    func combined(with other: Self) -> Self
+}
+
+/// A type conforming to `TensorGroup` and `Combinable` that contains two tensors: one for features and one for labels.
+/// Can be used as a generic batch type on a Dataset for a wide variety of applications.
+public struct FeatureLabelBatch<FeatureType: TensorFlowScalar, LabelType: TensorFlowScalar>: TensorGroup, Combinable {
+    public let features: Tensor<FeatureType>
+    public let labels: Tensor<LabelType>
+
+    public func combined(with other: FeatureLabelBatch<FeatureType, LabelType>)
+                    -> FeatureLabelBatch<FeatureType, LabelType> {
+        return FeatureLabelBatch(features: self.features.concatenated(with: other.features),
+                                 labels: self.labels.concatenated(with: other.labels))
+    }
+}
+
+/// Allows a type to be converted to a given `TensorGroup`.
+public protocol TensorGroupConvertible {
+    associatedtype TensorType: TensorGroup
+
+    var tensorValue: TensorType { get }
+}
+
+/// Allows defining a direct mapping to a `FeatureLabelBatch`.
+public protocol FeatureLabelMapping: TensorGroupConvertible, Codable
+        where Self.TensorType == FeatureLabelBatch<FeatureType, LabelType> {
+    associatedtype FeatureType: TensorFlowScalar
+    associatedtype LabelType: TensorFlowScalar
+
+    static var NUM_FEATURES: Int { get }
+    var features: [FeatureType] { get }
+    var label: LabelType { get }
+}
+
+extension FeatureLabelMapping {
+    public var tensorValue: TensorType {
+        let features = self.features
+        let featuresTensor = Tensor<FeatureType>(shape: [1, features.count], scalars: features)
+        let labels = Tensor<LabelType>([self.label])
+        return FeatureLabelBatch(features: featuresTensor, labels: labels)
+    }
+}

--- a/Sources/TFMongoSwift/main.swift
+++ b/Sources/TFMongoSwift/main.swift
@@ -1,1 +1,0 @@
-// placeholder file


### PR DESCRIPTION
[SWIFT-494](https://jira.mongodb.org/browse/SWIFT-494)

This PR adds the public API for loading a TensorFlow `Dataset` from MongoDB. It also introduces a new type `MongoDataset` which provides similar functionality to `Dataset` but is backed by a cursor, never loading the full dataset into memory.

### Standard Tensorflow `Dataset`
Examples of "vanilla" TensorFlow dataset initialization:
```swift
/// Struct modeling the data in MongoDB
struct Iris: Codable {
    public let petalLength: Double
    public let petalWidth: Double
    public let sepalLength: Double
    public let sepalWidth: Double
    public let label: Int32
}

/// TensorGroup used in Dataset
struct IrisBatch: TensorGroup, InitializableFromSequence {
    public let features: Tensor<Double>
    public let labels: Tensor<Int32>

    /// InitializableFromSequence conformance
    public init<S: Sequence>(from sequence: S) where S.Element == Iris {
        let fs: [Double] = []
        let ls: [Int32] = []
        for iris in sequence {
            fs += [iris.petalLength, iris.petalWidth, iris.sepalLength, iris.sepalWidth]
            ls.append(iris.label)
        }
       self.features = Tensor<Double>(shape: [ls.count, 4], scalars: fs)
       self.labels = Tensor<Int32>(ls)
    }
}

let dataset = try Dataset<IrisBatch>(uri: "mongodb://localhost:27017", db: "tf", collection: "tf_train", collectionType: Iris.self)
let dataset = try Dataset<IrisBatch>(db: "tf", collection: "tf_train", collectionType: Iris.self)
let dataset = try Dataset<IrisBatch>(db: "tf", collection: "tf_train", filter: ["sepalLength": ["$gt": 0.75] as Document], collectionType: Iris.self)
let dataset = try Dataset<IrisBatch>(db: "tf", collection: "tf_train", pipeline: [...], outputType: <some type>)

let normalizedDataset = try Dataset<IrisBatch>(db: "tf", collection: "tf_train") { (data: inout IrisBatch) in
    print(data.features)
    print(data.labels)
}
```

The `InitializableFromSequence` conformance is often boilerplate, since (in my experience, at least) most of the time, the generic type of a `Dataset` will be basically a features/label tuple. To that end, I've introduced a `FeatureLabelMapping` protocol that users can conform their types to. This allows users to simply choose what their features and labels are based on each document in their collections, and they will be mapped automatically to a `TensorGroup` type `FLB<C: FeatureLabelMapping>`, also introduced as part of the API. This way, users can define both the structure of their MongoDB data and the structure of the `Dataset` batches in a single type.

Example of `FeatureLabelMapping` used with a TensorFlow `Dataset`:
```swift
public struct IrisMapping: FeatureLabelMapping {
    public let petalLength: Double
    public let petalWidth: Double
    public let sepalLength: Double
    public let sepalWidth: Double
    public let label: Int32
    
    public static let shape = TensorShape([-1, 4])
    
    public var features: [Double] = [self.petalLength, self.petalWidth, self.sepalLength, self.sepalWidth]
}

let dataset = try Dataset<FLB>(db: "tf", collection: "iris_train", collectionType: IrisMapping.self)

public struct IrisArrayMapping: FeatureLabelMapping {
    public static let featureShape = TensorShape([1, 4])
    
    public let features: [Double]
    public let label: Int32
}

let pipeline: [Document] = [
    ["$project":[
        "features": ["$sepalLength", "$sepalWidth", "$petalLength", "$petalWidth"],
        "label": "$irisLabel"
    ] as Document]
]
let dataset = try Dataset<FLB>("db", collection: "iris_train", pipeline: pipeline, outputType: IrisArrayMapping.self)
```
Note that similar results can be achieved by just using the driver and vanilla TensorFlow:
```swift
let client = try MongoClient()
let elements = Array(client.db("tf").collection("tf_train", withType: Iris.self).find())
let features = Tensor<Double>(shape: [labels.count, 4], scalars: elements.reduce([]) { $0 + [$1.petalLength, $1.petalWidth, $1.sepalLength, $1.sepalWidth] })
let labels = Tensor<Int32>(elements.reduce([]) { $0.append($1.irisLabel.rawValue) })
let dataset = Dataset<IrisBatch>(elements: IrisBatch(features: features, labels: labels))
```

### `MongoDataset<C, T>`
As mentioned above, a new type `MongoDataset<C, T>` is also introduced as part of the public API. It is different from a regular `Dataset` in that its data is never loaded entirely in memory. It lazily retrieves each batch from a cursor before yielding it. The `C` generic type refers to the `Codable` mapping of the collection data, the `T` generic is the `TensorGroup` type.

Examples of using a `MongoDataset`:
```swift
let dataset = try MongoDataset<Iris, IrisBatch>(uri: "mongodb://localhost:27017", db: "tf", collection: "tf_train")
let dataset = try MongoDataset<Iris, IrisBatch>(db: "tf", collection: "tf_train")
let dataset = try MongoDataset<Iris, IrisBatch>(db: "tf", collection: "tf_train", filter: ["sepalLength": ["$gt": 0.75] as Document])
let dataset = try MongoDataset<<some type>, IrisBatch>(db: "tf", collection: "tf_train", pipeline: [...])
```

`FeatureLabelMapping` can also be used together with `MongoDataset`:
```swift
let dataset = try MongoDataset<IrisMapping, FLB<IrisMapping>>(db: "tf", collection: "iris_train")
let dataset = try MongoDataset<IrisArrayMapping, FLB<IrisArrayMapping>>("db", collection: "iris_train", pipeline: pipeline)
```